### PR TITLE
add references to the deployed version of the example app

### DIFF
--- a/R/run_example.R
+++ b/R/run_example.R
@@ -3,6 +3,9 @@
 #' This function runs an example R Shiny app showcasing different parts of the package.
 #' Code for the app can be found in the inst/example_app folder in the source code.
 #'
+#' The app is also deployed at the following URL:
+#' https://department-for-education.shinyapps.io/shinygovstyle-example-app/
+#'
 #' @return runs an R Shiny app with examples in
 #' @keywords example
 #' @export

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-This package provides custom widgets to style R Shiny apps using the GOV.UK design system.
+This package provides custom widgets to style R Shiny apps using the GOV.UK design system. The components can be previewed in our [example showcase app](https://department-for-education.shinyapps.io/shinygovstyle-example-app/).
 
 To view details and advice on how to use the GOV.UK components please visit https://design-system.service.gov.uk/components/, most components should be available to use through this package.
 
@@ -47,7 +47,7 @@ This package is also released with a [Contributor Code of Conduct](.github/CODE_
 
 ### Available components
 
-The package contains an example app you can run yourself, showcasing available components. The code for the example app is in the `inst/example_app/` folder. Though you can easily run the app from the console using:
+The package contains an [example showcase app](https://department-for-education.shinyapps.io/shinygovstyle-example-app/) you can view or run yourself, showcasing available components. The code for the example app is in the `inst/example_app/` folder. You can easily run the app from the console using:
 
 ```r
 shinyGovstyle::run_example()

--- a/inst/example_app/app.R
+++ b/inst/example_app/app.R
@@ -1,3 +1,5 @@
+# Deployed at https://department-for-education.shinyapps.io/shinygovstyle-example-app/
+
 library(shinyGovstyle)
 
 Months <- c("January", "February", "March")

--- a/man/run_example.Rd
+++ b/man/run_example.Rd
@@ -13,6 +13,10 @@ runs an R Shiny app with examples in
 This function runs an example R Shiny app showcasing different parts of the package.
 Code for the app can be found in the inst/example_app folder in the source code.
 }
+\details{
+The app is also deployed at the following URL:
+https://department-for-education.shinyapps.io/shinygovstyle-example-app/
+}
 \examples{
 if (interactive()) {
   run_example()


### PR DESCRIPTION
## Overview of changes

Quick PR to add the links into the new deployed version of the `run_example()` app. This resolves #110, though most of the work has been in other PRs and some direct to master commits playing trial and error with the deployment script.

## PR Checklist

- [x] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

App is now viewable at https://department-for-education.shinyapps.io/shinygovstyle-example-app/.

The app is built from GitHub, so takes the latest from master and a lot of the time will be more up to date than what is available on CRAN. I debated this a little and decided that was probably more helpful than the app being behind the development version, particularly with it being helpful for testing comparisons between local and master branches.

Main review here is to check you can access the app at the links added and there's no typos, though in case it's helpful the deployment script (not changed in this PR) can be viewed at https://github.com/dfe-analytical-services/shinyGovstyle/blob/master/.github/workflows/example-app-deploy.yaml