### PR TITLE
Softened rules around alt text in header from errors to warnings

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -7,11 +7,11 @@
 #' use the crown svg version on gov uk.
 #' @param main_link Add a link for clicking on main text.
 #' @param secondary_link Add a link for clicking on secondary header.
-#' @param logo_alt_text Add alternative text for the logo. Must be used when a
+#' @param logo_alt_text Add alternative text for the logo. Should be used when a
 #' logo is used.
-#' @param main_alt_text Add alternative text for the main link. Must be used
+#' @param main_alt_text Add alternative text for the main link. Should be used
 #' when a main link is used.
-#' @param secondary_alt_text Add alternative text for the secondary link. Must
+#' @param secondary_alt_text Add alternative text for the secondary link. Should
 #' be used when a secondary link is used.
 #' @param logo_width Change the logo size width CSS to improve fit.
 #' @param logo_height Change the logo size height CSS to improve fit.
@@ -46,15 +46,15 @@ header <- function(main_text,
                    logo_height = 32) {
   # checks for alt text
   if (!is.null(logo) & is.null(logo_alt_text)) {
-    stop("Please use logo_alt_text to provide alternative text for the logo you used.")
+    warning("Please use logo_alt_text to provide alternative text for the logo you used.")
   }
 
   if (main_link != "#" & is.null(main_alt_text)) {
-    stop("Please use main_alt_text to provide alternative text for the main link you used.")
+    warning("Please use main_alt_text to provide alternative text for the main link you used.")
   }
 
   if (secondary_link != "#" & is.null(secondary_alt_text)) {
-    stop("Please use secondary_alt_text to provide alternative text for the secondary link you used.")
+    warning("Please use secondary_alt_text to provide alternative text for the secondary link you used.")
   }
 
   if (is.null(logo)) {

--- a/man/header.Rd
+++ b/man/header.Rd
@@ -29,13 +29,13 @@ use the crown svg version on gov uk.}
 
 \item{secondary_link}{Add a link for clicking on secondary header.}
 
-\item{logo_alt_text}{Add alternative text for the logo. Must be used when a
+\item{logo_alt_text}{Add alternative text for the logo. Should be used when a
 logo is used.}
 
-\item{main_alt_text}{Add alternative text for the main link. Must be used
+\item{main_alt_text}{Add alternative text for the main link. Should be used
 when a main link is used.}
 
-\item{secondary_alt_text}{Add alternative text for the secondary link. Must
+\item{secondary_alt_text}{Add alternative text for the secondary link. Should
 be used when a secondary link is used.}
 
 \item{logo_width}{Change the logo size width CSS to improve fit.}

--- a/tests/testthat/test-header.R
+++ b/tests/testthat/test-header.R
@@ -107,7 +107,7 @@ test_that("only secondary link alt works", {
 
 # testing for errors
 test_that("errors are as expected", {
-  expect_error(
+  expect_warning(
     header(
       main_text = "test text",
       secondary_text = "test text 2",
@@ -116,7 +116,7 @@ test_that("errors are as expected", {
     "Please use logo_alt_text to provide alternative text for the logo you used."
   )
 
-  expect_error(
+  expect_warning(
     header(
       main_text = "test text",
       secondary_text = "test text 2",
@@ -125,7 +125,7 @@ test_that("errors are as expected", {
     "Please use main_alt_text to provide alternative text for the main link you used."
   )
 
-  expect_error(
+  expect_warning(
     header(
       main_text = "test text",
       secondary_text = "test text 2",


### PR DESCRIPTION
## Overview of changes

The alt text that was added in the header was becoming a bit of an awkward breaking change, whilst we're managing versions between dfeshiny and shinyGovstyle. I've softened the rules from errors to warnings for now to give a bit of a grace period, whilst dashboards are getting up to speed.

## PR Checklist

- [x] I have updated the documentation (if needed)
- [x] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

<!-- Put any specific questions, instructions or notes for reviewers in here -->
