### PR TITLE
make accordian open/close by clicking on any part of the section

### DIFF
--- a/inst/www/js/accordion.js
+++ b/inst/www/js/accordion.js
@@ -1,5 +1,5 @@
 // individual section buttons
-$(document).on('click', '.govuk-accordion__section-button', function (e) {
+$(document).on('click', '.govuk-accordion__section', function (e) {
 
   // get 'name' value from button
   var str = e.target.name;


### PR DESCRIPTION
## Overview of changes

Update accordion to open when you click anywhere on the accordion in line with govuk. Fixes #123.

## PR Checklist

- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`
