### PR TITLE
add downloads and lifecycle badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 [![CRAN status](https://www.r-pkg.org/badges/version/shinyGovstyle)](https://cran.r-project.org/package=shinyGovstyle)
 [![R-CMD-check](https://github.com/moj-analytical-services/shinyGovstyle/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/moj-analytical-services/shinyGovstyle/actions/workflows/R-CMD-check.yaml)
+[![](https://cranlogs.r-pkg.org/badges/shinyGovstyle)](https://cran.r-project.org/package=shinyGovstyle)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+
 <!-- badges: end -->
 
 > Apply Gov styled components and formats in shiny

--- a/shinyGovstyle.Rproj
+++ b/shinyGovstyle.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: ab9c9bc7-4ba5-4288-9748-bfe0e542c4c1
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
## Overview of changes

Spotted it was quite easy to add a downloads badge so figured it might be interesting to watch and see if we can grow adoption of this as we add to it.

Added the experimental lifecycle badge while we're still making big changes - expect when we get to v1.0.0 on CRAN we can mark it as stable (thinking either after the next milestone, or after we have done a big update on the layout side).

Adds a ProjectID to the Rproject file, seems to be a default thing R Studio does now so no harm in adding in.

## PR Checklist

- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

Not a lot to do here! Looks like this
![image](https://github.com/user-attachments/assets/c76bbc52-de2e-4429-a46b-95629cab823c)
