### PR TITLE
Fix cookies banner link in example app

### DIFF
--- a/inst/example_app/app.R
+++ b/inst/example_app/app.R
@@ -412,6 +412,11 @@ shiny::shinyApp(
   ), # end of fluid page
 
   server = function(input, output, session) {
+    # Cookies link from banner
+    shiny::observeEvent(input$cookieLink, {
+      shiny::updateTabsetPanel(session, "tab-container", selected = "panel-cookies")
+    })
+
     # Tab nav
     shiny::observeEvent(input$select_types_button, {
       shiny::updateTabsetPanel(session, "tab-container", selected = "select_types")


### PR DESCRIPTION
## Overview of changes

Quick one that fixes #119, as I was bogged down in bigger chunks of work and wanted to pick off a nice easy one I knew I could do quickly!

As @sarahmwong suggested in the issue we were just missing the server `observeEvent()` function to watch for the link being pressed, added that so it now changes the tab to the cookies page.

## PR Checklist

- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

Main thing is to run the test dashboard and check the link changes the page okay.