### PR TITLE
update to point to correct "for inputId" for selector

### DIFF
--- a/R/select_input.R
+++ b/R/select_input.R
@@ -35,7 +35,7 @@
 
 select_Input <- function(inputId, label, select_text, select_value){
   govSelect <- shiny::tags$div(class="govuk-form-group",
-    shiny::tags$label(shiny::HTML(label), class="govuk-label"),
+    shiny::tags$label(shiny::HTML(label), class="govuk-label", `for` = inputId),
     shiny::tags$select(id = inputId, class="govuk-select",
       Map(function(x,y){
         shiny::tags$option(value = y, x)


### PR DESCRIPTION
## Overview of changes

Updates html tag for the sorter label to point to the correct input Id

## PR Checklist

- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)
- [ x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

Check that the label tags look sensible to you now - should match up with what we can see in the gov.uk frontend
