### PR TITLE
Use snapshot testing for markup that wraps actionButton()/actionLink()

### DIFF
--- a/tests/testthat/_snaps/footer.md
+++ b/tests/testthat/_snaps/footer.md
@@ -1,0 +1,127 @@
+# footer links add correctly
+
+    Code
+      footer_with_links
+    Output
+      <footer class="govuk-footer " role="contentinfo">
+        <div class="govuk-width-container ">
+          <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+              <div>
+                <h2 class="govuk-visually-hidden">Support links</h2>
+                <ul class="govuk-footer__inline-list">
+                  <li class="govuk-footer__inline-list-item">
+                    <a class="action-button govuk-link govuk-footer__link" href="#" id="accessibility_statement">Accessibility Statement</a>
+                  </li>
+                  <li class="govuk-footer__inline-list-item">
+                    <a class="action-button govuk-link govuk-footer__link" href="#" id="cookies">Cookies</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+
+---
+
+    Code
+      full_footer_with_links
+    Output
+      <footer class="govuk-footer " role="contentinfo">
+        <div class="govuk-width-container ">
+          <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+              <div>
+                <h2 class="govuk-visually-hidden">Support links</h2>
+                <ul class="govuk-footer__inline-list">
+                  <li class="govuk-footer__inline-list-item">
+                    <a class="action-button govuk-link govuk-footer__link" href="#" id="privacy_notice">Privacy Notice</a>
+                  </li>
+                  <li class="govuk-footer__inline-list-item">
+                    <a class="action-button govuk-link govuk-footer__link" href="#" id="cookies">Cookies</a>
+                  </li>
+                </ul>
+              </div>
+              <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+                <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
+              </svg>
+              <span class="govuk-footer__licence-description">
+                All content is available under the
+                <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>
+                , except where otherwise stated
+              </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+              <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+
+---
+
+    Code
+      full_footer_with_internal_external_links
+    Output
+      <footer class="govuk-footer " role="contentinfo">
+        <div class="govuk-width-container ">
+          <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+              <div>
+                <h2 class="govuk-visually-hidden">Support links</h2>
+                <ul class="govuk-footer__inline-list">
+                  <li class="govuk-footer__inline-list-item">
+                    <a class="action-button govuk-link govuk-footer__link" href="#" id="privacy_notice_link">Privacy Notice</a>
+                  </li>
+                  <li class="govuk-footer__inline-list-item"><a href="https://github.com/dfe-analytical-services/shinyGovstyle" class="govuk-link govuk-footer__link" target="_blank" rel="noopener noreferrer">GitHub repository<span class="sr-only"> (opens in new tab)</span></a></li>
+                </ul>
+              </div>
+              <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+                <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
+              </svg>
+              <span class="govuk-footer__licence-description">
+                All content is available under the
+                <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>
+                , except where otherwise stated
+              </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+              <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+
+---
+
+    Code
+      full_footer_with_external_links
+    Output
+      <footer class="govuk-footer " role="contentinfo">
+        <div class="govuk-width-container ">
+          <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+              <div>
+                <h2 class="govuk-visually-hidden">Support links</h2>
+                <ul class="govuk-footer__inline-list">
+                  <li class="govuk-footer__inline-list-item"><a href="https://github.com/dfe-analytical-services/shinyGovstyle" class="govuk-link govuk-footer__link" target="_blank" rel="noopener noreferrer">Privacy notice<span class="sr-only"> (opens in new tab)</span></a></li>
+                  <li class="govuk-footer__inline-list-item"><a href="https://github.com/dfe-analytical-services/shinyGovstyle" class="govuk-link govuk-footer__link" target="_blank" rel="noopener noreferrer">GitHub repository<span class="sr-only"> (opens in new tab)</span></a></li>
+                </ul>
+              </div>
+              <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+                <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
+              </svg>
+              <span class="govuk-footer__licence-description">
+                All content is available under the
+                <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>
+                , except where otherwise stated
+              </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+              <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+

--- a/tests/testthat/test-backlink_Input.R
+++ b/tests/testthat/test-backlink_Input.R
@@ -1,9 +1,3 @@
 test_that("backlink works", {
-  backlink_check <- backlink_Input("backId")
-
-  expect_identical(
-    backlink_check$children[[1]][[2]],
-    "Back"
-  )
-
+  expect_no_error(backlink_Input("backId"))
 })

--- a/tests/testthat/test-footer.R
+++ b/tests/testthat/test-footer.R
@@ -17,34 +17,21 @@ test_that("test default footer", {
 })
 
 test_that("footer links add correctly", {
+  local_edition(3)
+
   footer_with_links <- footer(
     links = c("Accessibility Statement", "Cookies")
-  ) |>
-    paste0()
+  )
 
-  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"accessibility_statement\">Accessibility Statement</a>'
-  expect_true(grepl(expected_html, footer_with_links, fixed = TRUE))
-
-  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"cookies\">Cookies</a>'
-  expect_true(grepl(expected_html, footer_with_links, fixed = TRUE))
-
-  expected_html <- '<h2 class=\"govuk-visually-hidden\">Support links</h2>\n          <ul class=\"govuk-footer__inline-list\">\n            <li class=\"govuk-footer__inline-list-item\">'
-  expect_true(grepl(expected_html, footer_with_links, fixed = TRUE))
+  expect_snapshot(footer_with_links)
 
   full_footer_with_links <- footer(
     TRUE,
     c("Privacy Notice", "Cookies")
-  ) |>
-    paste0()
+  )
 
-  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"privacy_notice\">Privacy Notice</a>'
-  expect_true(grepl(expected_html, full_footer_with_links, fixed = TRUE))
 
-  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"cookies\">Cookies</a>'
-  expect_true(grepl(expected_html, full_footer_with_links, fixed = TRUE))
-
-  expected_html <- '<h2 class=\"govuk-visually-hidden\">Support links</h2>\n          <ul class=\"govuk-footer__inline-list\">\n            <li class=\"govuk-footer__inline-list-item\">'
-  expect_true(grepl(expected_html, full_footer_with_links, fixed = TRUE))
+  expect_snapshot(full_footer_with_links)
 
   full_footer_with_internal_external_links <- footer(
     TRUE,
@@ -52,14 +39,9 @@ test_that("footer links add correctly", {
       `Privacy Notice` = "privacy_notice_link",
       `GitHub repository` = "https://github.com/dfe-analytical-services/shinyGovstyle"
     )
-  ) |>
-    paste0()
+  )
 
-  expected_html <- '<a class=\"action-button govuk-link govuk-footer__link\" href=\"#\" id=\"privacy_notice_link\">Privacy Notice</a>'
-  expect_true(grepl(expected_html, full_footer_with_internal_external_links, fixed = TRUE))
-
-  expected_html <- '<a href=\"https://github.com/dfe-analytical-services/shinyGovstyle\" class=\"govuk-link govuk-footer__link\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub repository<span class=\"sr-only\"> (opens in new tab)</span></a>'
-  expect_true(grepl(expected_html, full_footer_with_internal_external_links, fixed = TRUE))
+  expect_snapshot(full_footer_with_internal_external_links)
 
   full_footer_with_external_links <- footer(
     TRUE,
@@ -67,12 +49,7 @@ test_that("footer links add correctly", {
       `Privacy notice` = "https://github.com/dfe-analytical-services/shinyGovstyle",
       `GitHub repository` = "https://github.com/dfe-analytical-services/shinyGovstyle"
     )
-  ) |>
-    paste0()
+  )
 
-  expected_html <- '<a href=\"https://github.com/dfe-analytical-services/shinyGovstyle\" class=\"govuk-link govuk-footer__link\" target=\"_blank\" rel=\"noopener noreferrer\">Privacy notice<span class=\"sr-only\"> (opens in new tab)</span></a>'
-  expect_true(grepl(expected_html, full_footer_with_external_links, fixed = TRUE))
-
-  expected_html <- '<a href=\"https://github.com/dfe-analytical-services/shinyGovstyle\" class=\"govuk-link govuk-footer__link\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub repository<span class=\"sr-only\"> (opens in new tab)</span></a>'
-  expect_true(grepl(expected_html, full_footer_with_external_links, fixed = TRUE))
+  expect_snapshot(full_footer_with_external_links)
 })


### PR DESCRIPTION
Hello, I'm a core contributor to Shiny, and this PR is in anticipation for https://github.com/rstudio/shiny/pull/4249, where we plan on making changes to the return value of `actionButton()`/`actionLink()`, which will break these tests.

Generally speaking, tests shouldn't be making such strong assumptions about the return value of Shiny UI functions. This is especially true of tests running on CRAN -- it blocks us from doing a release for changes that have a small chance of breaking existing behavior.

That said, you may have CSS/JS that truly does rely on a certain HTML markup produced by Shiny. In that case, you should consider using [snapshot testing](https://testthat.r-lib.org/articles/snapshotting.html) to capture and maintain relevant markup expectations. Crucially, since snapshots are inherently brittle, they do not run on CRAN, but will run everywhere else, and can be easily updated when snapshots change.