### PR TITLE
167 fix example app

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 _\.new\.png$
 ^[.]?air[.]toml$
 ^\.vscode$
+package.json

--- a/inst/example_app/app.R
+++ b/inst/example_app/app.R
@@ -1,7 +1,6 @@
 # Deployed at https://department-for-education.shinyapps.io/shinygovstyle-example-app/
 
 library(shinyGovstyle)
-library(dplyr) #needed for the pipe to filter reactive data example!
 
 Months <- rep(c("January", "February", "March", "April", "May"), times = 2)
 Colours <- rep(c("Red", "Blue"), times = 5)
@@ -706,7 +705,7 @@ shiny::shinyApp(
     )
 
     filtered_data <- reactive({
-      example_data %>% filter(Colours == input$colourFilter)
+      example_data |> filter(Colours == input$colourFilter)
     })
 
     output$interactive_table_test <- renderGovReactable({


### PR DESCRIPTION
## Overview of changes

Quick one, fixes #167 and also removes a note from the R CMD check I introduced in #161 when adding the package.json file to attempt to track the GOV.UK version.

<img width="385" height="86" alt="image" src="https://github.com/user-attachments/assets/1f44c97e-4493-4f88-8b3e-b8ad39bfb44b" />

For the fix on the example app, as we don't use dplyr in the package itself, I figured just switching to the base R pipe should solve the issue and prevent us needing to add any extra dependencies in.

## PR Checklist

- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

Check the app runs for you locally `shinyGovstyle::run_example()`, and there's no notes in the R CMD check around unexpected files.

The full / true test of the app fix will be when it's deployed to shinyapps.io