### PR TITLE
Fix example app reactive table outputs

### DIFF
--- a/inst/example_app/app.R
+++ b/inst/example_app/app.R
@@ -705,7 +705,7 @@ shiny::shinyApp(
     )
 
     filtered_data <- reactive({
-      example_data[example_data$Colours == input$colourFilter, ]
+      subset(example_data, Colours == input$colourFilter)
     })
 
     output$interactive_table_test <- renderGovReactable({

--- a/inst/example_app/app.R
+++ b/inst/example_app/app.R
@@ -705,7 +705,7 @@ shiny::shinyApp(
     )
 
     filtered_data <- reactive({
-      example_data |> filter(Colours == input$colourFilter)
+      example_data[example_data$Colours == input$colourFilter, ]
     })
 
     output$interactive_table_test <- renderGovReactable({


### PR DESCRIPTION
## Overview of changes

@sarahmwong I've figured this out and this PR fixes #169.

It was the same PR where I brought the base R pipe in (#168) but it wasn't the pipe, it was removing the dplyr library call that then changed filter to be the [base R filter](https://www.rdocumentation.org/packages/stats/versions/3.6.2/topics/filter) instead (from the stats package), which behaves quite differently!

I've swapped it for `subset()`, which is the closest base R equivalent to `dplyr::filter()` and all seems to be working fine again.

Sorry about this, when I checked on that branch I must have already had dplyr loaded in the environment without realising!

## PR Checklist

- [ ] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

Run the example app and check it's working for you locally.