### PR TITLE
Update rems and weights for links

### DIFF
--- a/R/full_width_overrides.R
+++ b/R/full_width_overrides.R
@@ -18,7 +18,7 @@ full_width_overrides <- function() {
       shiny::HTML(
         # Overall overrides
         ".container-fluid { padding: 0; }",
-        ".govuk-width-container { max-width: 100%; padding-left: 10px; }",
+        ".govuk-width-container { max-width: 100%; padding-left: 40px; }",
         ".govuk-grid-row { margin-left: 0; margin-right: 0; }",
 
         # Cookie banner overrides

--- a/css_changes.md
+++ b/css_changes.md
@@ -297,4 +297,16 @@ color: #0b0c0c;
 
 ```
 
+* Styling for accessible download links
+```
+/* download links--------------------------------- */
+
+.shiny-download-link {
+    font-size: 1.2rem;
+    font-weight:bold;
+}
+
+```
+
+
 

--- a/inst/www/css/govuk-frontend-5.9.0.min.css
+++ b/inst/www/css/govuk-frontend-5.9.0.min.css
@@ -7968,3 +7968,13 @@
     box-shadow: inset 0 -0.188rem 0 0 #1d70b8;
 }
 
+/* download links--------------------------------- */
+
+.shiny-download-link {
+    font-size: 1.2rem;
+    font-weight:bold;
+}
+
+
+
+

--- a/inst/www/css/govuk-frontend-5.9.0.min.css
+++ b/inst/www/css/govuk-frontend-5.9.0.min.css
@@ -14,7 +14,9 @@
     -moz-osx-font-smoothing: grayscale;
     text-decoration: underline;
     text-decoration-thickness: max(1px, .0625rem);
-    text-underline-offset: .1578em
+    text-underline-offset: .1578em;
+    font-size: 1.2rem;
+    font-weight: bold;
 }
 
 

--- a/inst/www/css/govuk-frontend-5.9.0.min.css
+++ b/inst/www/css/govuk-frontend-5.9.0.min.css
@@ -20,7 +20,7 @@
 
 @media print {
     .govuk-link {
-        font-family: sans-serif
+        font-family: sans-serif;
     }
 }
 
@@ -7850,13 +7850,15 @@
 
 .govuk-contents__link {
     padding-left: 0;
-    font-size: 1.5rem;
+    font-size: 1.2rem;
+    font-weight: bold;
 }
 
 .govuk-subcontents {
     list-style-type: none;
     padding-left: 0;
-    font-size: 1.5rem;
+    font-size: 1.2rem;
+    font-weight: bold;
 }
 
 /*Only display subcontents for first one - on load*/
@@ -7886,7 +7888,7 @@
 .value-box-container {
     font-family: GDS Transport, Arial, sans-serif;
     font-weight: 400;
-    font-size: 1.5rem;
+    font-size: 1rem;
     line-height: 1;
     box-sizing: border-box;
     padding: 10px;

--- a/inst/www/css/govuk-frontend-5.9.0.min.css
+++ b/inst/www/css/govuk-frontend-5.9.0.min.css
@@ -2,7 +2,7 @@
 
 :root {
     --govuk-frontend-version: "5.9.0";
-    font-size: 16px;
+    font-size: 1.2rem;
     --govuk-frontend-breakpoint-mobile: 20rem;
     --govuk-frontend-breakpoint-tablet: 40.0625rem;
     --govuk-frontend-breakpoint-desktop: 48.0625rem
@@ -22,7 +22,7 @@
 
 @media print {
     .govuk-link {
-        font-family: sans-serif;
+        font-family: sans-serif
     }
 }
 
@@ -732,8 +732,8 @@
     font-family: GDS Transport, arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 1rem;
+    font-weight: bold;
+    font-size: 1.2rem;
     line-height: 1.1875;
     display: inline-block;
     max-width: 100%;
@@ -4767,7 +4767,7 @@
 }
 
 .govuk-phase-banner__content__tag {
-    font-size: .875rem;
+    font-size: 1.2rem;
     line-height: 1.1428571429;
     margin-right: 10px
 }
@@ -4781,14 +4781,15 @@
 
 @media print {
     .govuk-phase-banner__content__tag {
-        font-size: 14pt;
+        font-size: 1.2rem;
         line-height: 1.2
     }
 }
 
 .govuk-phase-banner__text {
     display: table-cell;
-    vertical-align: middle
+    vertical-align: middle;
+    font-size: 1.2rem
 }
 
 .govuk-radios__item {

--- a/inst/www/css/govuk-frontend-5.9.0.min.css
+++ b/inst/www/css/govuk-frontend-5.9.0.min.css
@@ -7850,13 +7850,13 @@
 
 .govuk-contents__link {
     padding-left: 0;
-    font-size: 1rem;
+    font-size: 1.5rem;
 }
 
 .govuk-subcontents {
     list-style-type: none;
     padding-left: 0;
-    font-size: 1rem;
+    font-size: 1.5rem;
 }
 
 /*Only display subcontents for first one - on load*/
@@ -7886,7 +7886,7 @@
 .value-box-container {
     font-family: GDS Transport, Arial, sans-serif;
     font-weight: 400;
-    font-size: 1rem;
+    font-size: 1.5rem;
     line-height: 1;
     box-sizing: border-box;
     padding: 10px;


### PR DESCRIPTION
## Overview of changes

Increases rem on contents links to 1.2 to meet WCAG AAA as outlined in #194 and adds bold weight. Updated for external and download links too.

Identifies new bug #208 where contents pane spills over onto main app - faffed with the interim fix on full_width_overrides() just so the example app doesn't look weird! 

## PR Checklist

- [x] I have updated the documentation (if needed)
- [ ] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

Check that links now meet the WCAG standards but function still remains in example app
