### PR TITLE
Allow taglists for text content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/
 *_.new.png
 .claude/
 inst/doc
+AGENTS.md

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyGovstyle
 Title: Custom Gov Style Inputs for Shiny
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: c(
     person("Ross", "Wyatt", , "ross.wyatt@justice.gov.uk", role = "aut"),
     person("Cam", "Race", , "camrace8@gmail.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # shinyGovstyle (development version)
 
+## Breaking changes
+
+* `insert_text()` argument `text` has been renamed to `content` to reflect
+  that it now accepts more than plain text. The old name is deprecated and
+  will be removed in a future version.
+
+## New features
+
+* `insert_text()` (`content`), `panel_output()` (`sub_text`), `noti_banner()`
+  (`body_txt`), `details()` (`help_text`), `banner()` (`label`),
+  `warning_text()` (`text`), and `gov_summary()` (`info`) now accept `shiny`
+  tag objects (e.g. `shiny::tags$b("Bold")`) and `shiny::tagList()` values in
+  addition to plain character strings.
+
 ## Bug fixes
 
 * `header()` no longer emits spurious deprecation warnings for `main_link`,
@@ -7,6 +21,10 @@
   arguments are not used.
 * Error messages on input components now use `role="alert"` so they are
   announced by screen readers when toggled via `error_on()`.
+* `details()` now applies the same HTML handling to `help_text` as it does to
+  `label`, so HTML strings render consistently across both arguments.
+* `warning_text()` now renders HTML strings in `text` consistently with other
+  body-content components.
 
 # shinyGovstyle 0.2.0
 

--- a/R/banner.R
+++ b/R/banner.R
@@ -4,7 +4,8 @@
 #' details.
 #' @param inputId The input slot that will be used to access the value
 #' @param type Main type of label e.g. alpha or beta. Can be any word
-#' @param label text to display
+#' @param label Text to display. Accepts a plain character string, or `shiny`
+#' tag objects such as `shiny::tags$b("Bold")` or a `shiny::tagList()`.
 #' @return a banner HTML shiny tag object
 #' @family Govstyle page structure
 #' @export
@@ -39,7 +40,10 @@ banner <- function(
           class = "govuk-tag govuk-phase-banner__content__tag",
           type
         ),
-        shiny::tags$span(class = "govuk-phase-banner__text", shiny::HTML(label))
+        shiny::tags$span(
+          class = "govuk-phase-banner__text",
+          as_govuk_html(label)
+        )
       )
     )
   )

--- a/R/details.R
+++ b/R/details.R
@@ -4,7 +4,9 @@
 #' details.
 #' @param inputId The input slot that will be used to access the value
 #' @param label Main label text
-#' @param help_text Additional help information in the component
+#' @param help_text Additional help information in the component. Accepts a
+#' plain character string, or `shiny` tag objects such as
+#' `shiny::tags$b("Bold")` or a `shiny::tagList()`.
 #' @return a details box HTML shiny tag object
 #' @family Govstyle feedback types
 #' @export
@@ -44,7 +46,7 @@ details <- function(
         shiny::HTML(label)
       )
     ),
-    shiny::tags$div(class = "govuk-details__text", help_text)
+    shiny::tags$div(class = "govuk-details__text", as_govuk_html(help_text))
   )
   attachDependency(gov_details)
 }

--- a/R/insert_text.R
+++ b/R/insert_text.R
@@ -47,7 +47,7 @@ insert_text <- # nolint
   ) {
     if (lifecycle::is_present(text)) {
       lifecycle::deprecate_warn(
-        when = "1.0.0",
+        when = "0.3.0",
         what = "insert_text(text)",
         with = "insert_text(content)"
       )

--- a/R/insert_text.R
+++ b/R/insert_text.R
@@ -3,7 +3,10 @@
 #' This function loads the insert text component to display additional
 #' information in a special format.
 #' @param inputId The input slot that will be used to access the value
-#' @param text Text that you want to display on the insert
+#' @param content Content to display on the insert. Accepts a plain character
+#' string, or `shiny` tag objects such as `shiny::tags$b("Bold")` or a
+#' `shiny::tagList()`.
+#' @param text `r lifecycle::badge("deprecated")` Use `content` instead
 #' @return a insert text HTML shiny tag object
 #' @family Govstyle feedback types
 #' @export
@@ -18,9 +21,16 @@
 #'     size = "two-thirds",
 #'     shinyGovstyle::insert_text(
 #'       inputId = "note",
-#'       text = paste(
+#'       content = paste(
 #'         "It can take up to 8 weeks to register a lasting power of",
 #'         "attorney if there are no mistakes in the application."
+#'       )
+#'     ),
+#'     shinyGovstyle::insert_text(
+#'       inputId = "note-rich",
+#'       content = shiny::tagList(
+#'         shiny::tags$b("Important: "),
+#'         "you can also pass tag objects."
 #'       )
 #'     )
 #'   ),
@@ -32,10 +42,29 @@
 insert_text <- # nolint
   function(
     inputId, # nolint
-    text
+    content,
+    text = lifecycle::deprecated()
   ) {
+    if (lifecycle::is_present(text)) {
+      lifecycle::deprecate_warn(
+        when = "1.0.0",
+        what = "insert_text(text)",
+        with = "insert_text(content)"
+      )
+      if (!missing(content)) {
+        stop(
+          "Supply only one of `content` or the deprecated `text`, not both.",
+          call. = FALSE
+        )
+      }
+      content <- text
+    }
+    if (missing(content)) {
+      stop("`content` is required.", call. = FALSE)
+    }
+
     gov_insert <- shiny::tags$div(
-      shiny::HTML(text),
+      as_govuk_html(content),
       id = inputId,
       class = "govuk-inset-text"
     )

--- a/R/noti_banner.R
+++ b/R/noti_banner.R
@@ -3,7 +3,9 @@
 #' This function creates a notification banner.
 #' @param inputId The input Id for the banner
 #' @param title_txt The wording that appears in the title
-#' @param body_txt The wording that appears in the banner body
+#' @param body_txt The wording that appears in the banner body. Accepts a
+#' plain character string, or `shiny` tag objects such as
+#' `shiny::tags$b("Bold")` or a `shiny::tagList()`.
 #' @param type The type of banner. Options are standard and success.
 #' Standard is default
 #' @return a notification HTML shiny tag object
@@ -55,7 +57,7 @@ noti_banner <- function(
       class = "govuk-notification-banner__content",
       shiny::tags$p(
         class = "govuk-notification-banner__heading",
-        shiny::HTML(body_txt)
+        as_govuk_html(body_txt)
       )
     )
   )

--- a/R/panel_output.R
+++ b/R/panel_output.R
@@ -3,7 +3,9 @@
 #' This function inserts a panel.  Normally used for confirmation screens
 #' @param inputId The input slot that will be used to access the value.
 #' @param main_text Add the header for the panel
-#' @param sub_text Add the main body of text for the panel
+#' @param sub_text Add the main body of text for the panel. Accepts a plain
+#' character string, or `shiny` tag objects such as `shiny::tags$b("Bold")`
+#' or a `shiny::tagList()`.
 #' @return a panel HTML shiny tag object
 #' @family Govstyle feedback types
 #' @export
@@ -38,7 +40,7 @@ panel_output <- function(
     class = "govuk-panel govuk-panel--confirmation",
     id = inputId,
     shiny::tags$h1(main_text, class = "govuk-panel__title"),
-    shiny::tags$div(shiny::HTML(sub_text), class = "govuk-panel__body")
+    shiny::tags$div(as_govuk_html(sub_text), class = "govuk-panel__body")
   )
   attachDependency(gov_panel)
 }

--- a/R/summary.R
+++ b/R/summary.R
@@ -4,7 +4,10 @@
 #' with a grouping variable.
 #' @param inputId The Id to access the summary list
 #' @param headers input for the row headers value
-#' @param info summary information values for the table
+#' @param info Summary information values for the table. Each value accepts a
+#' plain character string, or `shiny` tag objects such as
+#' `shiny::tags$b("Bold")` or a `shiny::tagList()`. Pass a list rather than a
+#' character vector to mix tag and string values.
 #' @param action whenever a change link is needed. Sets input to the value of
 #' the headers using lowercase and with underscore to replace gaps. Default
 #' set to `FALSE`
@@ -69,7 +72,7 @@ gov_summary <- function(
           ),
           shiny::tags$dd(
             class = "govuk-summary-list__value",
-            shiny::HTML(y)
+            as_govuk_html(y)
           ),
           if (action) {
             shiny::tags$dd(

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,10 @@
+# Internal helper: passes through shiny.tag, shiny.tag.list, or HTML() output
+# unchanged so callers can supply tags. Wraps plain character strings with
+# shiny::HTML() to preserve the existing behaviour for string callers.
+as_govuk_html <- function(x) {
+  if (inherits(x, c("shiny.tag", "shiny.tag.list", "html"))) {
+    x
+  } else {
+    shiny::HTML(x)
+  }
+}

--- a/R/warning_text.R
+++ b/R/warning_text.R
@@ -2,7 +2,9 @@
 #'
 #' This function create warning text.
 #' @param inputId The input slot that will be used to access the value
-#' @param text Text that goes in the main
+#' @param text Text that goes in the main. Accepts a plain character string,
+#' or `shiny` tag objects such as `shiny::tags$b("Bold")` or a
+#' `shiny::tagList()`.
 #' @return a warning box HTML shiny tag object
 #' @family Govstyle feedback types
 #' @export
@@ -24,7 +26,7 @@ warning_text <- function(
       `aria-hidden` = "true"
     ),
     shiny::tags$strong(
-      text,
+      as_govuk_html(text),
       class = "govuk-warning-text__text",
       shiny::tags$span("Warning", class = "govuk-visually-hidden")
     )

--- a/inst/example_app/modules/mod_feedback_types.R
+++ b/inst/example_app/modules/mod_feedback_types.R
@@ -33,7 +33,7 @@ mod_feedback_types_ui <- function(id) {
     shinyGovstyle::heading_text("insert_text", size = "s", level = 2),
     shinyGovstyle::insert_text(
       inputId = shiny::NS(id, "insertId"),
-      text = "It can take up to 8 weeks to register a lasting
+      content = "It can take up to 8 weeks to register a lasting
                 power of attorney if there are no mistakes in the
                 application."
     ),

--- a/man/banner.Rd
+++ b/man/banner.Rd
@@ -11,7 +11,8 @@ banner(inputId, type, label)
 
 \item{type}{Main type of label e.g. alpha or beta. Can be any word}
 
-\item{label}{text to display}
+\item{label}{Text to display. Accepts a plain character string, or \code{shiny}
+tag objects such as \code{shiny::tags$b("Bold")} or a \code{shiny::tagList()}.}
 }
 \value{
 a banner HTML shiny tag object

--- a/man/details.Rd
+++ b/man/details.Rd
@@ -11,7 +11,9 @@ details(inputId, label, help_text)
 
 \item{label}{Main label text}
 
-\item{help_text}{Additional help information in the component}
+\item{help_text}{Additional help information in the component. Accepts a
+plain character string, or \code{shiny} tag objects such as
+\code{shiny::tags$b("Bold")} or a \code{shiny::tagList()}.}
 }
 \value{
 a details box HTML shiny tag object

--- a/man/gov_summary.Rd
+++ b/man/gov_summary.Rd
@@ -11,7 +11,10 @@ gov_summary(inputId, headers, info, action = FALSE, border = TRUE)
 
 \item{headers}{input for the row headers value}
 
-\item{info}{summary information values for the table}
+\item{info}{Summary information values for the table. Each value accepts a
+plain character string, or \code{shiny} tag objects such as
+\code{shiny::tags$b("Bold")} or a \code{shiny::tagList()}. Pass a list rather than a
+character vector to mix tag and string values.}
 
 \item{action}{whenever a change link is needed. Sets input to the value of
 the headers using lowercase and with underscore to replace gaps. Default

--- a/man/insert_text.Rd
+++ b/man/insert_text.Rd
@@ -4,12 +4,16 @@
 \alias{insert_text}
 \title{Insert Text Function}
 \usage{
-insert_text(inputId, text)
+insert_text(inputId, content, text = lifecycle::deprecated())
 }
 \arguments{
 \item{inputId}{The input slot that will be used to access the value}
 
-\item{text}{Text that you want to display on the insert}
+\item{content}{Content to display on the insert. Accepts a plain character
+string, or \code{shiny} tag objects such as \code{shiny::tags$b("Bold")} or a
+\code{shiny::tagList()}.}
+
+\item{text}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{content} instead}
 }
 \value{
 a insert text HTML shiny tag object
@@ -29,9 +33,16 @@ ui <- shiny::fluidPage(
     size = "two-thirds",
     shinyGovstyle::insert_text(
       inputId = "note",
-      text = paste(
+      content = paste(
         "It can take up to 8 weeks to register a lasting power of",
         "attorney if there are no mistakes in the application."
+      )
+    ),
+    shinyGovstyle::insert_text(
+      inputId = "note-rich",
+      content = shiny::tagList(
+        shiny::tags$b("Important: "),
+        "you can also pass tag objects."
       )
     )
   ),

--- a/man/noti_banner.Rd
+++ b/man/noti_banner.Rd
@@ -16,7 +16,9 @@ noti_banner(
 
 \item{title_txt}{The wording that appears in the title}
 
-\item{body_txt}{The wording that appears in the banner body}
+\item{body_txt}{The wording that appears in the banner body. Accepts a
+plain character string, or \code{shiny} tag objects such as
+\code{shiny::tags$b("Bold")} or a \code{shiny::tagList()}.}
 
 \item{type}{The type of banner. Options are standard and success.
 Standard is default}

--- a/man/panel_output.Rd
+++ b/man/panel_output.Rd
@@ -11,7 +11,9 @@ panel_output(inputId, main_text, sub_text)
 
 \item{main_text}{Add the header for the panel}
 
-\item{sub_text}{Add the main body of text for the panel}
+\item{sub_text}{Add the main body of text for the panel. Accepts a plain
+character string, or \code{shiny} tag objects such as \code{shiny::tags$b("Bold")}
+or a \code{shiny::tagList()}.}
 }
 \value{
 a panel HTML shiny tag object

--- a/man/warning_text.Rd
+++ b/man/warning_text.Rd
@@ -9,7 +9,9 @@ warning_text(inputId, text)
 \arguments{
 \item{inputId}{The input slot that will be used to access the value}
 
-\item{text}{Text that goes in the main}
+\item{text}{Text that goes in the main. Accepts a plain character string,
+or \code{shiny} tag objects such as \code{shiny::tags$b("Bold")} or a
+\code{shiny::tagList()}.}
 }
 \value{
 a warning box HTML shiny tag object

--- a/tests/testthat/test-banner.R
+++ b/tests/testthat/test-banner.R
@@ -1,13 +1,31 @@
-test_that("banner check", {
-  banner_check <- banner("bannerId", "alpha", "Banner test")
+test_that("banner renders type tag and string label", {
+  out <- banner("bannerId", "alpha", "Banner test")
 
-  expect_identical(
-    banner_check$children[[1]]$children[[1]]$children[[1]]$children[[1]],
-    "alpha"
+  html <- as.character(out)
+  expect_match(html, "govuk-phase-banner", fixed = TRUE)
+  expect_match(html, "alpha", fixed = TRUE)
+  expect_match(html, "Banner test", fixed = TRUE)
+})
+
+test_that("label accepts a shiny.tag", {
+  out <- banner("bannerId", "beta", shiny::tags$b("Bold label"))
+
+  expect_match(as.character(out), "<b>Bold label</b>", fixed = TRUE)
+})
+
+test_that("label accepts a tagList with an external link", {
+  out <- banner(
+    "bannerId",
+    "beta",
+    shiny::tagList(
+      "This is a new service - your ",
+      shiny::tags$a(href = "https://example.com", "feedback"),
+      " will help us improve it."
+    )
   )
 
-  expect_identical(
-    banner_check$children[[1]]$children[[1]]$children[[2]]$children[[1]],
-    shiny::HTML("Banner test")
-  )
+  html <- as.character(out)
+  expect_match(html, "This is a new service", fixed = TRUE)
+  expect_match(html, "href=\"https://example.com\"", fixed = TRUE)
+  expect_match(html, ">feedback</a>", fixed = TRUE)
 })

--- a/tests/testthat/test-details.R
+++ b/tests/testthat/test-details.R
@@ -1,13 +1,33 @@
-test_that("details work", {
-  check_details <- details("detailId", "Test Main", "Test Second")
+test_that("string label and help_text render as HTML inside the details", {
+  out <- details("detailId", "Test Main", "Test Second")
 
-  expect_identical(
-    check_details$children[[1]]$children[[1]]$children[[1]],
-    shiny::HTML("Test Main")
+  html <- as.character(out)
+  expect_match(html, "govuk-details", fixed = TRUE)
+  expect_match(html, "Test Main", fixed = TRUE)
+  expect_match(html, "Test Second", fixed = TRUE)
+})
+
+test_that("help_text accepts a tagList", {
+  out <- details(
+    "detailId",
+    label = "Label",
+    help_text = shiny::tagList(
+      shiny::tags$p("Paragraph one."),
+      shiny::tags$p("Paragraph two.")
+    )
   )
 
-  expect_identical(
-    check_details$children[[2]]$children[[1]],
-    "Test Second"
+  html <- as.character(out)
+  expect_match(html, "<p>Paragraph one.</p>", fixed = TRUE)
+  expect_match(html, "<p>Paragraph two.</p>", fixed = TRUE)
+})
+
+test_that("help_text accepts a single shiny.tag", {
+  out <- details(
+    "detailId",
+    label = "Label",
+    help_text = shiny::tags$p("Just a paragraph.")
   )
+
+  expect_match(as.character(out), "<p>Just a paragraph.</p>", fixed = TRUE)
 })

--- a/tests/testthat/test-insert_text.R
+++ b/tests/testthat/test-insert_text.R
@@ -1,18 +1,50 @@
-test_that("multiplication works", {
+test_that("string content is wrapped with shiny::HTML", {
   insert_text <- insert_text("insert1", "Test insert")
 
-  expect_identical(
-    insert_text$attribs$id,
-    "insert1"
-  )
+  expect_identical(insert_text$attribs$id, "insert1")
+  expect_identical(insert_text$attribs$class, "govuk-inset-text")
+  expect_match(as.character(insert_text), "Test insert", fixed = TRUE)
+})
 
-  expect_identical(
-    insert_text$attribs$class,
-    "govuk-inset-text"
-  )
+test_that("single shiny.tag content is rendered inside the inset", {
+  tag <- shiny::tags$b("Bold inside")
+  out <- insert_text("insert-tag", tag)
 
-  expect_identical(
-    shiny::HTML("Test insert"),
-    insert_text$children[[1]]
+  html <- as.character(out)
+  expect_match(html, "govuk-inset-text", fixed = TRUE)
+  expect_match(html, "<b>Bold inside</b>", fixed = TRUE)
+})
+
+test_that("tagList content is rendered inside the inset", {
+  content <- shiny::tagList(
+    shiny::tags$b("A link: "),
+    shiny::tags$a(href = "https://example.com", "link text")
   )
+  out <- insert_text("insert-list", content)
+
+  html <- as.character(out)
+  expect_match(html, "<b>A link: </b>", fixed = TRUE)
+  expect_match(html, "href=\"https://example.com\"", fixed = TRUE)
+  expect_match(html, ">link text</a>", fixed = TRUE)
+})
+
+test_that("deprecated `text` argument still works with a warning", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  expect_warning(
+    out <- insert_text("insert-dep", text = "Old style"),
+    class = "lifecycle_warning_deprecated"
+  )
+  expect_match(as.character(out), "Old style", fixed = TRUE)
+})
+
+test_that("supplying both `content` and `text` errors", {
+  rlang::local_options(lifecycle_verbosity = "quiet")
+  expect_error(
+    insert_text("insert-both", content = "new", text = "old"),
+    "Supply only one"
+  )
+})
+
+test_that("missing `content` errors", {
+  expect_error(insert_text("insert-missing"), "`content` is required")
 })

--- a/tests/testthat/test-noti_banner.R
+++ b/tests/testthat/test-noti_banner.R
@@ -1,36 +1,50 @@
-test_that("noti banner works", {
-  noti_check <- shinyGovstyle::noti_banner(
+test_that("noti banner renders title and string body", {
+  out <- shinyGovstyle::noti_banner(
     inputId = "banner",
     title_txt = "Important",
     body_txt = "Example text"
   )
 
-  expect_identical(
-    noti_check$children[[1]]$children[[1]]$children[[1]],
-    "Important"
-  )
-
-  expect_identical(
-    noti_check$children[[2]]$children[[1]]$children[[1]],
-    shiny::HTML("Example text")
-  )
+  html <- as.character(out)
+  expect_match(html, "govuk-notification-banner", fixed = TRUE)
+  expect_match(html, "Important", fixed = TRUE)
+  expect_match(html, "Example text", fixed = TRUE)
 })
 
-test_that("noti success banner works", {
-  noti_check <- shinyGovstyle::noti_banner(
+test_that("noti success banner uses success class and alert role", {
+  out <- shinyGovstyle::noti_banner(
     inputId = "banner",
     title_txt = "Important",
     body_txt = "Example text",
     type = "success"
   )
 
-  expect_identical(
-    noti_check$children[[1]]$children[[1]]$children[[1]],
-    "Important"
+  html <- as.character(out)
+  expect_match(html, "govuk-notification-banner--success", fixed = TRUE)
+  expect_match(html, "role=\"alert\"", fixed = TRUE)
+})
+
+test_that("body_txt accepts a shiny.tag", {
+  out <- shinyGovstyle::noti_banner(
+    inputId = "banner",
+    title_txt = "Important",
+    body_txt = shiny::tags$b("Bold body")
   )
 
-  expect_identical(
-    noti_check$children[[2]]$children[[1]]$children[[1]],
-    shiny::HTML("Example text")
+  expect_match(as.character(out), "<b>Bold body</b>", fixed = TRUE)
+})
+
+test_that("body_txt accepts a tagList", {
+  out <- shinyGovstyle::noti_banner(
+    inputId = "banner",
+    title_txt = "Important",
+    body_txt = shiny::tagList(
+      shiny::tags$b("Heads up: "),
+      shiny::tags$a(href = "https://example.com", "follow up")
+    )
   )
+
+  html <- as.character(out)
+  expect_match(html, "<b>Heads up: </b>", fixed = TRUE)
+  expect_match(html, "href=\"https://example.com\"", fixed = TRUE)
 })

--- a/tests/testthat/test-panel_output.R
+++ b/tests/testthat/test-panel_output.R
@@ -1,13 +1,33 @@
-test_that("test panel", {
-  check_panel <- panel_output("panelId", "Main", "Second")
+test_that("string sub_text renders inside the panel body", {
+  out <- panel_output("panelId", "Main", "Second")
 
-  expect_identical(
-    check_panel$children[[1]]$children[[1]],
-    "Main"
+  html <- as.character(out)
+  expect_match(html, "govuk-panel--confirmation", fixed = TRUE)
+  expect_match(html, "Main", fixed = TRUE)
+  expect_match(html, "Second", fixed = TRUE)
+})
+
+test_that("sub_text accepts a shiny.tag", {
+  out <- panel_output(
+    "panelId",
+    main_text = "Main",
+    sub_text = shiny::tags$b("Bold body")
   )
 
-  expect_identical(
-    check_panel$children[[2]]$children[[1]],
-    shiny::HTML("Second")
+  expect_match(as.character(out), "<b>Bold body</b>", fixed = TRUE)
+})
+
+test_that("sub_text accepts a tagList", {
+  out <- panel_output(
+    "panelId",
+    main_text = "Main",
+    sub_text = shiny::tagList(
+      "Reference: ",
+      shiny::tags$strong("ABC123")
+    )
   )
+
+  html <- as.character(out)
+  expect_match(html, "Reference: ", fixed = TRUE)
+  expect_match(html, "<strong>ABC123</strong>", fixed = TRUE)
 })

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -29,3 +29,31 @@ test_that("summary list works", {
     "button"
   )
 })
+
+test_that("info accepts a list of mixed string and tag values", {
+  headers <- c("Name", "Address")
+  info <- list(
+    "Sarah Philips",
+    shiny::tagList(
+      "72 Guild Street", shiny::tags$br(),
+      "London", shiny::tags$br(),
+      "SE23 6FH"
+    )
+  )
+
+  out <- gov_summary("sumID", headers, info, action = FALSE)
+  html <- as.character(out)
+
+  expect_match(html, "Sarah Philips", fixed = TRUE)
+  expect_match(html, "72 Guild Street", fixed = TRUE)
+  expect_match(html, "<br/>", fixed = TRUE)
+  expect_match(html, "SE23 6FH", fixed = TRUE)
+})
+
+test_that("info accepts a list containing a single shiny.tag value", {
+  headers <- "Reference"
+  info <- list(shiny::tags$strong("ABC-123"))
+
+  out <- gov_summary("sumID", headers, info, action = FALSE)
+  expect_match(as.character(out), "<strong>ABC-123</strong>", fixed = TRUE)
+})

--- a/tests/testthat/test-warning_text.R
+++ b/tests/testthat/test-warning_text.R
@@ -17,12 +17,12 @@ test_that("text accepts a tagList", {
     "warningId",
     shiny::tagList(
       "You can be fined up to ",
-      shiny::tags$strong("£5,000"),
+      shiny::tags$i("£5,000"),
       " if you do not register."
     )
   )
 
   html <- as.character(out)
   expect_match(html, "You can be fined up to", fixed = TRUE)
-  expect_match(html, "<strong>£5,000</strong>", fixed = TRUE)
+  expect_match(html, "<i>£5,000</i>", fixed = TRUE)
 })

--- a/tests/testthat/test-warning_text.R
+++ b/tests/testthat/test-warning_text.R
@@ -1,8 +1,28 @@
-test_that("warning works", {
-  warn_check <- warning_text("warningId", "Test")
+test_that("warning renders string text in the body", {
+  out <- warning_text("warningId", "Test")
 
-  expect_identical(
-    warn_check$children[[2]]$children[[1]],
-    "Test"
+  html <- as.character(out)
+  expect_match(html, "govuk-warning-text", fixed = TRUE)
+  expect_match(html, "Test", fixed = TRUE)
+})
+
+test_that("text accepts a shiny.tag", {
+  out <- warning_text("warningId", shiny::tags$b("Bold warning"))
+
+  expect_match(as.character(out), "<b>Bold warning</b>", fixed = TRUE)
+})
+
+test_that("text accepts a tagList", {
+  out <- warning_text(
+    "warningId",
+    shiny::tagList(
+      "You can be fined up to ",
+      shiny::tags$strong("£5,000"),
+      " if you do not register."
+    )
   )
+
+  html <- as.character(out)
+  expect_match(html, "You can be fined up to", fixed = TRUE)
+  expect_match(html, "<strong>£5,000</strong>", fixed = TRUE)
 })

--- a/vignettes/headings-and-text.Rmd
+++ b/vignettes/headings-and-text.Rmd
@@ -21,6 +21,31 @@ This vignette covers all functions in shinyGovstyle that produce styled text con
 
 ---
 
+## Rich content in body components
+
+The body-content arguments of `insert_text()` (`content`), `warning_text()` (`text`), and `noti_banner()` (`body_txt`) accept more than plain character strings. You can pass a `shiny` tag, a `shiny::tagList()`, or `shiny::HTML()` output to embed inline emphasis, links, or line breaks without writing raw HTML.
+
+```{r, eval = FALSE}
+insert_text(
+  inputId = "processing-note",
+  content = shiny::tagList(
+    shiny::tags$b("Important: "),
+    "it can take up to 8 weeks to process. ",
+    shinyGovstyle::external_link(
+      "https://www.gov.uk/",
+      "View the latest information on GOV.UK"
+    ),
+    " before submitting."
+  )
+)
+```
+
+The same applies to `banner()` (`label`), `panel_output()` (`sub_text`), `details()` (`help_text`), and `gov_summary()` (`info`), which are covered in [Layout options](layout-options.html) and the function reference.
+
+Plain character strings continue to work unchanged, so the simpler per-component examples below remain valid.
+
+---
+
 ## `heading_text()`
 
 Creates a semantic HTML heading element with a GOV.UK heading CSS class.
@@ -137,7 +162,7 @@ Displays a GOV.UK inset text box — a bordered callout for supplementary inform
 ```{r, eval = FALSE}
 insert_text(
   inputId = "processing-note",
-  text = "It can take up to 8 weeks to process your application."
+  content = "It can take up to 8 weeks to process your application."
 )
 ```
 

--- a/vignettes/layout-options.Rmd
+++ b/vignettes/layout-options.Rmd
@@ -96,14 +96,17 @@ Displays a phase banner immediately below the header, used to indicate the matur
 banner(
   inputId = "phase-banner",
   type = "Beta",
-  label = paste0(
+  label = shiny::tagList(
     "This is a new service \u2014 your ",
-    '<a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+    shiny::tags$a(class = "govuk-link", href = "#", "feedback"),
+    " will help us to improve it."
   )
 )
 ```
 
-For more information on when and how to use this, read the documentation for the [GOV.UK Phase banner component](https://design-system.service.gov.uk/components/phase-banner/). 
+`label` also accepts a plain character string or raw HTML (e.g. `"...<a class=\"govuk-link\" href=\"#\">feedback</a>..."`); the `tagList()` form above is preferred for readability and to avoid hand-written HTML.
+
+For more information on when and how to use this, read the documentation for the [GOV.UK Phase banner component](https://design-system.service.gov.uk/components/phase-banner/).
 
 
 ### `footer()`


### PR DESCRIPTION
## Overview of changes

Resolves #221.

Allow text-content arguments across several components to accept `shiny` tag objects (e.g. `shiny::tags$b("Bold")`) and`shiny::tagList()` values, not just plain character strings. This makes it possible to compose more details content (e.g. with bold, links, line breaks, nested tags) without resorting to raw HTML strings.

  Components updated:
  - `insert_text()` — `content` (renamed from `text` as suggested in #221; old arg deprecated via `lifecycle`)
  - `panel_output()` — `sub_text`
  - `noti_banner()` — `body_txt`
  - `details()` — `help_text`
  - `banner()` — `label`
  - `warning_text()` — `text`
  - `gov_summary()` — `info`

A small internal helper `as_govuk_html()` (in `/utils.R`) centralises the logic: tag / tagList / HTML input passes through unchanged, plain strings continue to be wrapped with `shiny::HTML()` so existing behaviour is preserved and therefore this change should be backwards compatible.

## PR Checklist

- [x] I have updated the documentation (if needed)
- [x] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

Manually poke at a few of the changed functions and test the use case referenced in #221.

Test out the raw HTML still working, example in #178 for the beta banner.

Also tagging @rmbielby for sight, given it was their initial idea / request.