### PR TITLE
191 bug accordions dont fully announce state

### DIFF
--- a/R/accordion.R
+++ b/R/accordion.R
@@ -60,7 +60,6 @@ accordion <- function(
           class = "govuk-accordion__show-all",
           `aria-expanded` = "false",
           shiny::tags$span(
-            id = "show-all-chevron",
             class = paste(
               "govuk-accordion-nav__chevron",
               "govuk-accordion-nav__chevron--down"
@@ -90,6 +89,7 @@ accordion <- function(
                   class = "govuk-accordion__section-button",
                   id = paste0("accordion-default-heading-", z_str),
                   name = paste0("accordion-default-heading-", z_str),
+                  `aria-expanded` = "false",
                   shiny::tags$span(
                     class = "govuk-accordion__section-heading-text",
                     shiny::tags$span(

--- a/inst/www/js/accordion.js
+++ b/inst/www/js/accordion.js
@@ -1,104 +1,109 @@
-// individual section buttons
+// On click of individual sections
 $(document).on('click', '.govuk-accordion__section', function (e) {
 
-  // get 'name' value from button
-  var str = e.target.name;
-
-  // get z value from name (Map argument)
-  var level = str.substr(str.length - 2);
-
-
-
   // get class from top div
-  var cur_class = $('[name="accordion-default-heading-' + level + '"]').parent().parent().parent()[0].classList.value
+  var top_div = e.target.closest('.govuk-accordion__section');
+
+  var cur_class = top_div.classList.value;
+
+  var button = e.target.closest('button');
+  var toggle_chevron = button.querySelector(".govuk-accordion-nav__chevron");
+  var toggle_text = button.querySelector(".govuk-accordion__section-toggle-text");
 
 
   // check if "govuk-accordion__section--expanded" has already been added to the top div class
-  if (cur_class == "govuk-accordion__section") {
+ if (cur_class == "govuk-accordion__section") {
 
-    // add  "govuk-accordion__section--expanded" to top div class
-    $('[name="accordion-default-heading-' + level + '"]').parent().parent().parent().addClass("govuk-accordion__section--expanded");
+   top_div.classList.add("govuk-accordion__section--expanded");
+   toggle_chevron.classList.remove("govuk-accordion-nav__chevron--down");
+   toggle_text.innerText = "Hide";
+   button.ariaExpanded = "true";
 
-    // remove chevron transform class
-    $('[name="accordion-default-heading-' + level + '"]').children().children().children().removeClass("govuk-accordion-nav__chevron--down")[0];
+ } else {
 
-    // edit toggle text
-    $('[name="accordion-default-heading-' + level + '"]').children().children().children()[1].innerHTML = "Hide"
+   // this section deos the opposite of above
 
-  } else {
+   top_div.classList.remove("govuk-accordion__section--expanded");
+   toggle_chevron.classList.add("govuk-accordion-nav__chevron--down");
+   toggle_text.innerText = "Show";
+   button.ariaExpanded = "false";
 
-    // remove "govuk-accordion__section--expanded" to top div class
-    $('[name="accordion-default-heading-' + level + '"]').parent().parent().parent().removeClass("govuk-accordion__section--expanded");
 
-    // add chevron transform class
-    $('[name="accordion-default-heading-' + level + '"]').children().children().children().addClass("govuk-accordion-nav__chevron--down")[0];
+ }
 
-     // edit toggle text
-    $('[name="accordion-default-heading-' + level + '"]').children().children().children()[1].innerHTML = "Show"
-
-     // if any section set to hidden want "Show all text" and chevron down
-    document.getElementById("show-all-chevron").classList.add("govuk-accordion-nav__chevron--down")
-    document.getElementsByClassName("govuk-accordion__show-all-text")[0].innerHTML = "Show all sections"
-  }
 
 });
 
-// show all button
+// On click of Show All/Hide all
 $(document).on('click', '.govuk-accordion__show-all', function (e) {
 
-  // get all section elements
-  var sections = document.getElementsByClassName('govuk-accordion__section');
+ // navigate to current accordion
+ var show_all_button = e.target.closest('button');
 
-  // get all chevron elements
-  var chevrons = document.getElementsByClassName('govuk-accordion-nav__chevron');
+ // get relevant Show All elements
+ var show_all_chevron = show_all_button.querySelector(".govuk-accordion-nav__chevron");
+ var show_all_text = show_all_button.querySelector(".govuk-accordion__show-all-text");
 
-  // get toggle text element
-  var toggle_text = document.getElementsByClassName('govuk-accordion__section-toggle-text');
+ // get current direction of Show All chevron
+ var show_all_chevron_class = show_all_chevron.classList.value;
 
-  // get current class value for the show all chevron
-  var show_all_chevron_class = document.getElementById("show-all-chevron").classList.value;
+if (show_all_chevron_class != "govuk-accordion-nav__chevron"){
+
+   // update accordion controls
+   show_all_text.innerText  = "Hide all sections";
+   show_all_chevron.classList.remove("govuk-accordion-nav__chevron--down");
+   show_all_button.ariaExpanded = "true";
+
+} else {
+
+  // do opposite of above
+  show_all_text.innerText  = "Show all sections";
+  show_all_chevron.classList.add("govuk-accordion-nav__chevron--down");
+  show_all_button.ariaExpanded = "false";
+
+}
+
+// navigate to top of current accordion
+var top_div = e.target.closest('.govuk-accordion');
+
+// get elements for all sections in an accordion
+var sections = top_div.querySelectorAll(".govuk-accordion__section");
+var chevrons = top_div.querySelectorAll(".govuk-accordion-nav__chevron");
+var toggle_text = top_div.querySelectorAll('.govuk-accordion__section-toggle-text');
+var buttons = top_div.querySelectorAll('.govuk-accordion__section-button');
 
 
-  for (var i = 0; i < sections.length; i++) {
+// repeat below for all sections in accordion
+for (var i = 0; i < sections.length; i++) {
 
-    // check direction of Show all chevron
-    if (show_all_chevron_class != "govuk-accordion-nav__chevron") {
+ // check if chevron class list includes expanded
+  if (show_all_chevron_class != "govuk-accordion-nav__chevron"){
 
-      // switch Show all text and chevon direction
-      document.getElementsByClassName("govuk-accordion__show-all-text")[0].innerHTML = "Hide all sections";
-      chevrons[0].classList.remove("govuk-accordion-nav__chevron--down");
-
-      // only switch individual sections if they are closed
-      if (sections[i].classList.value == "govuk-accordion__section") {
+        // add expanded clases
         sections[i].classList.add("govuk-accordion__section--expanded");
 
         // note: chevron elements length one greater than section length due to show all/hide all chevron
         chevrons[i + 1].classList.remove("govuk-accordion-nav__chevron--down");
 
         // change individual section text to "Hide"
-        toggle_text[i].innerHTML = "Hide";
+        toggle_text[i].innerText = "Hide";
 
-      }
+        // update aria-expanded attribute
+        buttons[i].ariaExpanded = "true";
 
 
-    } else {
+  } else {
 
-      // this else section does the opposite of the if section above
-      document.getElementsByClassName("govuk-accordion__show-all-text")[0].innerHTML = "Show all sections";
-      chevrons[0].classList.add("govuk-accordion-nav__chevron--down");
-
-      if (sections[i].classList.value != "govuk-accordion__section") {
+        // this section does the opposite of the above
         sections[i].classList.remove("govuk-accordion__section--expanded");
         chevrons[i + 1].classList.add("govuk-accordion-nav__chevron--down");
-
-        toggle_text[i].innerHTML = "Show";
-
-      }
-
-    }
+        toggle_text[i].innerText = "Show";
+        buttons[i].ariaExpanded = "false";
 
   }
 
+
+}
 
 
 });

--- a/tests/testthat/test-accordion.R
+++ b/tests/testthat/test-accordion.R
@@ -60,8 +60,12 @@ test_that("accordion numbering works past 9", {
 
   tq$find("#accordion-default-heading-01")$selectedTags()[[1]]$attribs$name
 
-  heading1 <- tq$find("#accordion-default-heading-01")$selectedTags()[[1]]$attribs$name
-  heading11 <- tq$find("#accordion-default-heading-11")$selectedTags()[[1]]$attribs$name
+  heading1 <- tq$find("#accordion-default-heading-01")$selectedTags()[[
+    1
+  ]]$attribs$name
+  heading11 <- tq$find("#accordion-default-heading-11")$selectedTags()[[
+    1
+  ]]$attribs$name
 
   expect_equal(stringr::str_sub(heading1, -2), "01")
   expect_equal(stringr::str_sub(heading11, -2), "11")

--- a/tests/testthat/test-accordion.R
+++ b/tests/testthat/test-accordion.R
@@ -1,3 +1,5 @@
+library(htmltools)
+
 test_that("accordion works", {
   accordion_check <- accordion(
     "acc1",
@@ -15,7 +17,9 @@ test_that("accordion works", {
     )
   )
 
-  expect_equal(length(accordion_check$children[[2]]), 4)
+  tq <- tagQuery(accordion_check)
+  t <- tq$find(".govuk-accordion__section")$selectedTags()
+  expect_equal(length(t), 4)
 })
 
 
@@ -52,12 +56,12 @@ test_that("accordion numbering works past 9", {
     )
   )
 
-  heading1 <- accordion_numbering_check$children[[2]][[1]]$children[[
-    1
-  ]]$children[[1]]$children[[1]]$attribs$name
-  heading11 <- accordion_numbering_check$children[[2]][[11]]$children[[
-    1
-  ]]$children[[1]]$children[[1]]$attribs$name
+  tq <- tagQuery(accordion_numbering_check)
+
+  tq$find("#accordion-default-heading-01")$selectedTags()[[1]]$attribs$name
+
+  heading1 <- tq$find("#accordion-default-heading-01")$selectedTags()[[1]]$attribs$name
+  heading11 <- tq$find("#accordion-default-heading-11")$selectedTags()[[1]]$attribs$name
 
   expect_equal(stringr::str_sub(heading1, -2), "01")
   expect_equal(stringr::str_sub(heading11, -2), "11")


### PR DESCRIPTION
## Overview of changes

Changes to accordions are:

1. Get accordions to work independently of each other (e.g a change to on accordion on a page will not affect another). Fixes #228 
2. Adds aria-expanded attribute to both show all/hide all controls and each section. This updates to true/false on click of both sections and show all/hide all. Fixes #191 
3. Rewrite code and tests to use class and element sectors instead of position selectors. Linked to #229 

## PR Checklist

- [ ] I have updated the documentation (if needed)
- [x] I have added or updated tests for these changes (if applicable)
- [x] I have tested these changes locally using `devtools::check()`

## Reviewer instructions

1. Manually test multiple accordions between tabs (and on the same tab) to check accordions work independently of each other. 

2. Test that aria-expanded shows correct value:
(i) by section when individual section changes
(ii) in controls when hide/all show all changes
(iii) for every section when hide all/show all changes
(iv) that (i)-(iii) work independently between accordions
