### PR TITLE
Fix vector logic (#724)

### DIFF
--- a/R/radio_button_input.R
+++ b/R/radio_button_input.R
@@ -301,7 +301,7 @@ generateOptions2 <- # nolint
             value = value,
             class = "govuk-radios__input"
           )
-        if (is.null(selected) == FALSE & value %in% selected) {
+        if (!is.null(selected) && value %in% selected) {
           inputTag$attribs$checked <- "checked" # nolint
         }
         pd <- processDeps2(name, session)


### PR DESCRIPTION
## Overview of changes

Fixes code-scanning alert [#724](https://github.com/dfe-analytical-services/shinyGovstyle/security/code-scanning/724): R/radio_button_input.R:304 used the vectorized & operator inside a scalar if() condition, which lintr's vector_logic_linter flags because & is intended for elementwise vector comparisons, not control-flow conditions.

Also simplified is.null(x) == FALSE to !is.null(x) for idiomatic style.

## Reviewer notes

It's a simple quick 'security' (i.e. linting) fix, I've checked the code after it was generated and am happy so will merge if the CI passes.